### PR TITLE
Move logback root logger from include file to application config.

### DIFF
--- a/pustefix-logging/pustefix-logback/src/main/resources/org/pustefixframework/logging/logback.xml
+++ b/pustefix-logging/pustefix-logback/src/main/resources/org/pustefixframework/logging/logback.xml
@@ -310,10 +310,4 @@
     <appender-ref ref="LOGGER_CSRF"/>
   </logger>
 
-  <!-- Default logger -->
-
-  <root level="${defaultLevel}">
-    <appender-ref ref="LOGGER_GENERAL" />
-  </root>
-
 </included>

--- a/pustefix-samples/pustefix-mvctest/src/main/resources/logback.xml
+++ b/pustefix-samples/pustefix-mvctest/src/main/resources/logback.xml
@@ -3,4 +3,8 @@
 
   <include resource="org/pustefixframework/logging/logback.xml"/>
 
+  <root level="${defaultLevel}">
+    <appender-ref ref="LOGGER_GENERAL" />
+  </root>
+
 </configuration>

--- a/pustefix-samples/pustefix-sample1/src/main/resources/logback.xml
+++ b/pustefix-samples/pustefix-sample1/src/main/resources/logback.xml
@@ -3,4 +3,9 @@
 
   <include resource="org/pustefixframework/logging/logback.xml"/>
 
+  <!-- Default logger -->
+  <root level="${defaultLevel}">
+    <appender-ref ref="LOGGER_GENERAL" />
+  </root>
+
 </configuration>


### PR DESCRIPTION
Thus it is possible to load the pustefix logback configuration, while
retaining the opportunity to override the root appender and level.
Multiple root loggers are not permitted according to logback
documentation.